### PR TITLE
If an invalid input JSON file is used, tell the user which key is missing

### DIFF
--- a/classes/interface/main_controller.py
+++ b/classes/interface/main_controller.py
@@ -205,35 +205,40 @@ class MainController(object):
 
     @staticmethod
     def build_hdf_filter(data):
-        channel = None
-        use_radiance_filters = None
-        data_quality_best = data['data_quality_best']  # bool
-        data_quality_enough = data['data_quality_enough']  # bool
-        data_quality_worst = data['data_quality_worst']  # bool
-        dust_flag_no_dust = data['dust_flag_no_dust']  # bool
-        dust_flag_single_fov = data['dust_flag_single_fov']  # bool
-        dust_flag_detected = data['dust_flag_detected']  # bool
-        landfrac_threshold = float(data['landfrac_threshold'])
-        landfrac_threshold_is_max = data['landfrac_threshold_is_max']  # bool
-        cloud_cover_threshold = data['TotCld_4_CCfinal_threshold']
-        cloud_cover_threshold_is_max = data['TotCld_4_CCfinal_threshold_is_max']
-        all_spots_avg_threshold = data['all_spots_avg_threshold']
-        all_spots_avg_threshold_is_max = data['all_spots_avg_threshold_is_max']
-        examine_wavenumber_mode = data['examine_wavenumber_mode']
-        selected_wavenumber = data['selected_wavenumber']
-        scanang = float(data['scanang_limit'])
-        inside_scanang = data['inside_scanang']  # bool
-        solzen_threshold = float(data['solzen_threshold'])
-        solzen_is_max = data['solzen_is_max']  # bool
+        try:
+            channel = None
+            use_radiance_filters = None
+            data_quality_best = data['data_quality_best']  # bool
+            data_quality_enough = data['data_quality_enough']  # bool
+            data_quality_worst = data['data_quality_worst']  # bool
+            dust_flag_no_dust = data['dust_flag_no_dust']  # bool
+            dust_flag_single_fov = data['dust_flag_single_fov']  # bool
+            dust_flag_detected = data['dust_flag_detected']  # bool
+            landfrac_threshold = float(data['landfrac_threshold'])
+            landfrac_threshold_is_max = data['landfrac_threshold_is_max']  # bool
+            cloud_cover_threshold = data['TotCld_4_CCfinal_threshold']
+            cloud_cover_threshold_is_max = data['TotCld_4_CCfinal_threshold_is_max']
+            all_spots_avg_threshold = data['all_spots_avg_threshold']
+            all_spots_avg_threshold_is_max = data['all_spots_avg_threshold_is_max']
+            examine_wavenumber_mode = data['examine_wavenumber_mode']
+            selected_wavenumber = data['selected_wavenumber']
+            scanang = float(data['scanang_limit'])
+            inside_scanang = data['inside_scanang']  # bool
+            solzen_threshold = float(data['solzen_threshold'])
+            solzen_is_max = data['solzen_is_max']  # bool
 
-        noise_amp = data['noise_amp']  # bool
-        radiance = None
-        radiance_range = None
+            noise_amp = data['noise_amp']  # bool
+            radiance = None
+            radiance_range = None
 
-        return HDFFilter(
-            use_radiance_filters, radiance, radiance_range, channel, data_quality_best, data_quality_enough,
-            data_quality_worst, landfrac_threshold, landfrac_threshold_is_max, cloud_cover_threshold,
-            cloud_cover_threshold_is_max, all_spots_avg_threshold, all_spots_avg_threshold_is_max, noise_amp,
-            dust_flag_no_dust, dust_flag_single_fov, dust_flag_detected, examine_wavenumber_mode, selected_wavenumber,
-            scanang, inside_scanang, solzen_threshold, solzen_is_max
-        )
+            return HDFFilter(
+                use_radiance_filters, radiance, radiance_range, channel, data_quality_best, data_quality_enough,
+                data_quality_worst, landfrac_threshold, landfrac_threshold_is_max, cloud_cover_threshold,
+                cloud_cover_threshold_is_max, all_spots_avg_threshold, all_spots_avg_threshold_is_max, noise_amp,
+                dust_flag_no_dust, dust_flag_single_fov, dust_flag_detected, examine_wavenumber_mode, selected_wavenumber,
+                scanang, inside_scanang, solzen_threshold, solzen_is_max
+            )
+
+        except KeyError as e:
+            print("Check your input JSON file, and make sure {} is specified there.".format(e))
+            exit(1)

--- a/classes/interface/main_controller.py
+++ b/classes/interface/main_controller.py
@@ -240,5 +240,5 @@ class MainController(object):
             )
 
         except KeyError as e:
-            print("Check your input JSON file, and make sure {} is specified there.".format(e))
+            print("A setting is missing. Check your input JSON file, and make sure {} is specified there.".format(e))
             exit(1)

--- a/test.json
+++ b/test.json
@@ -38,5 +38,7 @@
 	    "selected_wavenumber": 818.933,
 
 	    "scanang_limit": 30,
-	    "inside_scanang": true
+	    "inside_scanang": true,
+	    "solzen_threshold": 108,
+	    "solzen_is_max": false
         }


### PR DESCRIPTION
If the filter API is ever updated (like when we added solzen filters) and an older version of an input JSON file is used, tell the user which keys are missing from the file.

Example output with missing 'solzen_threshold' setting:

```
A setting is missing. Check your input JSON file, and make sure 'solzen_threshold' is specified there.
```

Also, the included test.json is an example of this older schema -- added solzen_threshold and solzen_is_max keys to that file, copied defaults from example.json