### PR TITLE
Add lat/lon intra-granule filter

### DIFF
--- a/classes/hdf.py
+++ b/classes/hdf.py
@@ -363,8 +363,8 @@ def extract_granule_dataset(granule, hdf_filter: HDFFilter):
 
 def filter_dataset(df: pd.DataFrame, radiances: pd.DataFrame, radiances_quality: pd.DataFrame, hdf_filter: HDFFilter):
     # Pre-filter data to only include data points within lat/lon specification
-    prefilter_geo_condition = (df.latitude >= hdf_filter.min_lat) & (df.latitude <= hdf_filter.max_lat)
-    prefilter_geo_condition &= (df.longitude >= hdf_filter.min_lon) & (df.longitude <= hdf_filter.max_lon)
+    prefilter_geo_condition = (df.latitude >= hdf_filter.min_lat) & (df.latitude < hdf_filter.max_lat)
+    prefilter_geo_condition &= (df.longitude >= hdf_filter.min_lon) & (df.longitude < hdf_filter.max_lon)
     radiances = radiances[prefilter_geo_condition]
 
     # start counting amount of data points removed by filters

--- a/classes/hdf.py
+++ b/classes/hdf.py
@@ -83,7 +83,8 @@ class HDFFilter(object):
                  data_quality_worst, landfrac_threshold, landfrac_threshold_is_max, cloud_cover_threshold,
                  cloud_cover_threshold_is_max, all_spots_avg_threshold, all_spots_avg_threshold_is_max, noise_amp,
                  dust_flag_no_dust, dust_flag_single_fov, dust_flag_detected, examine_wavenumber_mode,
-                 selected_wavenumber, scanang, inside_scanang, solzen_threshold, solzen_is_max):
+                 selected_wavenumber, scanang, inside_scanang, solzen_threshold, solzen_is_max, min_lat, max_lat,
+                 min_lon, max_lon):
         self.use_radiance_filters = use_radiance_filters
         self.radiance = radiance
         self.radiance_range = radiance_range
@@ -107,6 +108,10 @@ class HDFFilter(object):
         self.inside_scanang = inside_scanang
         self.solzen_threshold = solzen_threshold
         self.solzen_is_max = solzen_is_max
+        self.min_lat = min_lat
+        self.max_lat = max_lat
+        self.min_lon = min_lon
+        self.max_lon = max_lon
 
 
 class HDFStorage(object):

--- a/classes/hdf.py
+++ b/classes/hdf.py
@@ -320,6 +320,7 @@ def extract_granule_dataset(granule, hdf_filter: HDFFilter):
     all_spots = pd.DataFrame(data.select('all_spots_avg').get())
     final_noise_amp = pd.DataFrame(data.select('CCfinal_Noise_Amp').get())
     latitude = pd.DataFrame(data.select('Latitude').get())
+    longitude = pd.DataFrame(data.select('Longitude').get())
     scanang = pd.DataFrame(data.select('scanang').get())
     solzen = pd.DataFrame(data.select('solzen').get())
 
@@ -343,6 +344,7 @@ def extract_granule_dataset(granule, hdf_filter: HDFFilter):
         'cloud_cover': cloud_cover,
         'all_spots': all_spots,
         'latitude': latitude,
+        'longitude': longitude,
         'scanang': scanang,
         'solzen': solzen
     }
@@ -360,6 +362,11 @@ def extract_granule_dataset(granule, hdf_filter: HDFFilter):
 
 
 def filter_dataset(df: pd.DataFrame, radiances: pd.DataFrame, radiances_quality: pd.DataFrame, hdf_filter: HDFFilter):
+    # Pre-filter data to only include data points within lat/lon specification
+    prefilter_geo_condition = (df.latitude >= hdf_filter.min_lat) & (df.latitude <= hdf_filter.max_lat)
+    prefilter_geo_condition &= (df.longitude >= hdf_filter.min_lon) & (df.longitude <= hdf_filter.max_lon)
+    radiances = radiances[prefilter_geo_condition]
+
     # start counting amount of data points removed by filters
     num_data_points = radiances.count().sum()
     num_filtered_total = 0

--- a/classes/interface/main_controller.py
+++ b/classes/interface/main_controller.py
@@ -225,6 +225,10 @@ class MainController(object):
         inside_scanang = data['inside_scanang']  # bool
         solzen_threshold = float(data['solzen_threshold'])
         solzen_is_max = data['solzen_is_max']  # bool
+        min_lat = data['min_latitude']
+        max_lat = data['max_latitude']
+        min_lon = data['min_longitude']
+        max_lon = data['max_longitude']
 
         noise_amp = data['noise_amp']  # bool
         radiance = None
@@ -235,5 +239,5 @@ class MainController(object):
             data_quality_worst, landfrac_threshold, landfrac_threshold_is_max, cloud_cover_threshold,
             cloud_cover_threshold_is_max, all_spots_avg_threshold, all_spots_avg_threshold_is_max, noise_amp,
             dust_flag_no_dust, dust_flag_single_fov, dust_flag_detected, examine_wavenumber_mode, selected_wavenumber,
-            scanang, inside_scanang, solzen_threshold, solzen_is_max
+            scanang, inside_scanang, solzen_threshold, solzen_is_max, min_lat, max_lat, min_lon, max_lon
         )


### PR DESCRIPTION
Filter datapoints >= min lat/lon, < max lat/lon in input JSON.
This filtering happens first, and is not reported in filter stats. The proceeding filters with stats receive the granule data masked per lat/lon settings.