### PR TITLE
Add lat/lon intra-granule filter and expand search area 'four tier' style

### DIFF
--- a/classes/aqua_positions.py
+++ b/classes/aqua_positions.py
@@ -28,20 +28,20 @@ def calculate_lat_lon_filter_condition(data, min_lat, max_lat, min_lon, max_lon,
     if is_search_area:
         search_min_lat = normalize_latitude_arithmetic(min_lat - 10)
         search_max_lat = normalize_latitude_arithmetic(max_lat + 10)
-        latitude_condition = (data.lat >= search_min_lat) & (data.lat < search_max_lat)
+        latitude_condition = (data.lat >= search_min_lat) & (data.lat <= search_max_lat)
     else:
-        latitude_condition = (data.lat >= min_lat) & (data.lat < max_lat)
+        latitude_condition = (data.lat >= min_lat) & (data.lat <= max_lat)
 
     # include longitudes within the specified range considering whether or not the prime meridian is included
     lon_naively_contains_zero = (min_lon <= 0 <= max_lon)
-    longitude_condition = (data.lon >= min_lon) & (data.lon < max_lon)
+    longitude_condition = (data.lon >= min_lon) & (data.lon <= max_lon)
 
     # special logic for meridian setting
     special_meridian_logic = False
     if not ((lon_naively_contains_zero and include_prime_meridian) or
             (not lon_naively_contains_zero and not include_prime_meridian)):
         # take from the complement of the usual longitude slice
-        longitude_condition = (data.lon < min_lon) | (data.lon >= max_lon)
+        longitude_condition = (data.lon <= min_lon) | (data.lon >= max_lon)
         special_meridian_logic = True
 
     # Expand search area longitude further near the poles
@@ -49,7 +49,7 @@ def calculate_lat_lon_filter_condition(data, min_lat, max_lat, min_lon, max_lon,
         # 1st tier, +/- 10 degrees at absolute latitude < 60
         if special_meridian_logic:
             longitude_condition |= (
-                ((data.lon < normalize_longitude_arithmetic(min_lon + 10))
+                ((data.lon <= normalize_longitude_arithmetic(min_lon + 10))
                  |
                  (data.lon >= normalize_longitude_arithmetic(max_lon - 10)))
                 &
@@ -59,14 +59,14 @@ def calculate_lat_lon_filter_condition(data, min_lat, max_lat, min_lon, max_lon,
             longitude_condition |= (
                 ((data.lon >= normalize_longitude_arithmetic(min_lon - 10))
                  &
-                 (data.lon < normalize_longitude_arithmetic(max_lon + 10)))
+                 (data.lon <= normalize_longitude_arithmetic(max_lon + 10)))
                 &
                 ((data.lat > -60) & (data.lat < 60))
             )
         # 2nd tier, +/- 25 degrees at 60-70 absolute latitude
         if special_meridian_logic:
             longitude_condition |= (
-                ((data.lon < normalize_longitude_arithmetic(min_lon + 25))
+                ((data.lon <= normalize_longitude_arithmetic(min_lon + 25))
                  |
                  (data.lon >= normalize_longitude_arithmetic(max_lon - 25)))
                 &
@@ -76,14 +76,14 @@ def calculate_lat_lon_filter_condition(data, min_lat, max_lat, min_lon, max_lon,
             longitude_condition |= (
                 ((data.lon >= normalize_longitude_arithmetic(min_lon - 25))
                  &
-                 (data.lon < normalize_longitude_arithmetic(max_lon + 25)))
+                 (data.lon <= normalize_longitude_arithmetic(max_lon + 25)))
                 &
                 ((data.lat <= -60) | (data.lat >= 60))
             )
         # 3rd tier, +/- 45 degrees at 70-80 absolute latitude
         if special_meridian_logic:
             longitude_condition |= (
-                ((data.lon < normalize_longitude_arithmetic(min_lon + 45))
+                ((data.lon <= normalize_longitude_arithmetic(min_lon + 45))
                  |
                  (data.lon >= normalize_longitude_arithmetic(max_lon - 45)))
                 &
@@ -93,7 +93,7 @@ def calculate_lat_lon_filter_condition(data, min_lat, max_lat, min_lon, max_lon,
             longitude_condition |= (
                 ((data.lon >= normalize_longitude_arithmetic(min_lon - 45))
                  &
-                 (data.lon < normalize_longitude_arithmetic(max_lon + 45)))
+                 (data.lon <= normalize_longitude_arithmetic(max_lon + 45)))
                 &
                 ((data.lat <= -70) | (data.lat >= 70))
             )

--- a/classes/aqua_positions.py
+++ b/classes/aqua_positions.py
@@ -10,13 +10,13 @@ def calculate_longitude_filter_condition(data, min_longitude, max_longitude, inc
                                          is_search_area):
     # include longitudes within the specified range considering whether or not the prime meridian is included
     lon_naively_contains_zero = (min_longitude <= 0 <= max_longitude)
-    longitude_condition = (data.lon >= min_longitude) & (data.lon <= max_longitude)
+    longitude_condition = (data.lon >= min_longitude) & (data.lon < max_longitude)
 
     # special logic for meridian setting
     if not ((lon_naively_contains_zero and include_prime_meridian) or
             (not lon_naively_contains_zero and not include_prime_meridian)):
         # take from the complement of the usual longitude slice
-        longitude_condition = (data.lon <= min_longitude) | (data.lon >= max_longitude)
+        longitude_condition = (data.lon < min_longitude) | (data.lon >= max_longitude)
 
     return longitude_condition
 

--- a/classes/aqua_positions.py
+++ b/classes/aqua_positions.py
@@ -49,51 +49,51 @@ def calculate_lat_lon_filter_condition(data, min_lat, max_lat, min_lon, max_lon,
         # 1st tier, +/- 10 degrees at absolute latitude < 60
         if special_meridian_logic:
             longitude_condition |= (
-                (data.lon < normalize_longitude_arithmetic(min_lon + 10))
-                |
-                (data.lon >= normalize_longitude_arithmetic(max_lon - 10))
+                ((data.lon < normalize_longitude_arithmetic(min_lon + 10))
+                 |
+                 (data.lon >= normalize_longitude_arithmetic(max_lon - 10)))
                 &
                 ((data.lat > -60) & (data.lat < 60))
             )
         else:
             longitude_condition |= (
-                (data.lon >= normalize_longitude_arithmetic(min_lon - 10))
-                &
-                (data.lon < normalize_longitude_arithmetic(max_lon + 10))
+                ((data.lon >= normalize_longitude_arithmetic(min_lon - 10))
+                 &
+                 (data.lon < normalize_longitude_arithmetic(max_lon + 10)))
                 &
                 ((data.lat > -60) & (data.lat < 60))
             )
         # 2nd tier, +/- 25 degrees at 60-70 absolute latitude
         if special_meridian_logic:
             longitude_condition |= (
-                (data.lon < normalize_longitude_arithmetic(min_lon + 25))
-                |
-                (data.lon >= normalize_longitude_arithmetic(max_lon - 25))
+                ((data.lon < normalize_longitude_arithmetic(min_lon + 25))
+                 |
+                 (data.lon >= normalize_longitude_arithmetic(max_lon - 25)))
                 &
                 ((data.lat <= -60) | (data.lat >= 60))
             )
         else:
             longitude_condition |= (
-                (data.lon >= normalize_longitude_arithmetic(min_lon - 25))
-                &
-                (data.lon < normalize_longitude_arithmetic(max_lon + 25))
+                ((data.lon >= normalize_longitude_arithmetic(min_lon - 25))
+                 &
+                 (data.lon < normalize_longitude_arithmetic(max_lon + 25)))
                 &
                 ((data.lat <= -60) | (data.lat >= 60))
             )
         # 3rd tier, +/- 45 degrees at 70-80 absolute latitude
         if special_meridian_logic:
             longitude_condition |= (
-                (data.lon < normalize_longitude_arithmetic(min_lon + 45))
-                |
-                (data.lon >= normalize_longitude_arithmetic(max_lon - 45))
+                ((data.lon < normalize_longitude_arithmetic(min_lon + 45))
+                 |
+                 (data.lon >= normalize_longitude_arithmetic(max_lon - 45)))
                 &
                 ((data.lat <= -70) | (data.lat >= 70))
             )
         else:
             longitude_condition |= (
-                (data.lon >= normalize_longitude_arithmetic(min_lon - 45))
-                &
-                (data.lon < normalize_longitude_arithmetic(max_lon + 45))
+                ((data.lon >= normalize_longitude_arithmetic(min_lon - 45))
+                 &
+                 (data.lon < normalize_longitude_arithmetic(max_lon + 45)))
                 &
                 ((data.lat <= -70) | (data.lat >= 70))
             )

--- a/classes/aqua_positions.py
+++ b/classes/aqua_positions.py
@@ -22,12 +22,11 @@ def calculate_lat_lon_filter_condition(data, min_lat, max_lat, min_lon, max_lon,
 
     # Handle special logic for expanded search area
     if is_search_area:
-        min_lat = normalize_latitude_arithmetic(min_lat - 10)
-        max_lat = normalize_latitude_arithmetic(max_lat + 10)
-        min_lon = normalize_longitude_arithmetic(min_lon - 10)
-        max_lon = normalize_longitude_arithmetic(max_lon + 10)
-
-    latitude_condition = (data.lat >= min_lat) & (data.lat < max_lat)
+        search_min_lat = normalize_latitude_arithmetic(min_lat - 10)
+        search_max_lat = normalize_latitude_arithmetic(max_lat + 10)
+        latitude_condition = (data.lat >= search_min_lat) & (data.lat < search_max_lat)
+    else:
+        latitude_condition = (data.lat >= min_lat) & (data.lat < max_lat)
 
     # include longitudes within the specified range considering whether or not the prime meridian is included
     lon_naively_contains_zero = (min_lon <= 0 <= max_lon)
@@ -35,6 +34,14 @@ def calculate_lat_lon_filter_condition(data, min_lat, max_lat, min_lon, max_lon,
 
     # Expand search area longitude further near the poles
     if is_search_area:
+        # 1st tier, +/- 10 degrees at absolute latitude < 60
+        longitude_condition = (
+            (data.lon >= normalize_longitude_arithmetic(min_lon - 10))
+            &
+            (data.lon < normalize_longitude_arithmetic(max_lon + 10))
+            &
+            ((data.lat > -60) & (data.lat < 60))
+        )
         # 2nd tier, +/- 25 degrees at 60-70 absolute latitude
         longitude_condition |= (
             (data.lon >= normalize_longitude_arithmetic(min_lon - 25))

--- a/classes/aqua_positions.py
+++ b/classes/aqua_positions.py
@@ -14,11 +14,15 @@ def calculate_lat_lon_filter_condition(data, min_lat, max_lat, min_lon, max_lon,
         if latitude > 90:
             return 90
 
+        return latitude
+
     def normalize_longitude_arithmetic(longitude):
         if longitude < -180:
             return longitude % 180
         if longitude > 180:
             return -180 + (longitude % 180)
+
+        return longitude
 
     # Handle special logic for expanded search area
     if is_search_area:

--- a/classes/aqua_positions.py
+++ b/classes/aqua_positions.py
@@ -36,7 +36,7 @@ def calculate_lat_lon_filter_condition(data, min_lat, max_lat, min_lon, max_lon,
     if not ((lon_naively_contains_zero and include_prime_meridian) or
             (not lon_naively_contains_zero and not include_prime_meridian)):
         # take from the complement of the usual longitude slice
-        longitude_condition = ~longitude_condition
+        longitude_condition = (data.lon < min_lon) | (data.lon >= max_lon)
 
     # Expand search area longitude further near the poles
     if is_search_area:

--- a/classes/aqua_positions.py
+++ b/classes/aqua_positions.py
@@ -49,9 +49,9 @@ def calculate_lat_lon_filter_condition(data, min_lat, max_lat, min_lon, max_lon,
         # 1st tier, +/- 10 degrees at absolute latitude < 60
         if special_meridian_logic:
             longitude_condition |= (
-                (data.lon < normalize_longitude_arithmetic(min_lon - 10))
+                (data.lon < normalize_longitude_arithmetic(min_lon + 10))
                 |
-                (data.lon >= normalize_longitude_arithmetic(max_lon + 10))
+                (data.lon >= normalize_longitude_arithmetic(max_lon - 10))
                 &
                 ((data.lat > -60) & (data.lat < 60))
             )
@@ -66,9 +66,9 @@ def calculate_lat_lon_filter_condition(data, min_lat, max_lat, min_lon, max_lon,
         # 2nd tier, +/- 25 degrees at 60-70 absolute latitude
         if special_meridian_logic:
             longitude_condition |= (
-                (data.lon < normalize_longitude_arithmetic(min_lon - 25))
+                (data.lon < normalize_longitude_arithmetic(min_lon + 25))
                 |
-                (data.lon >= normalize_longitude_arithmetic(max_lon + 25))
+                (data.lon >= normalize_longitude_arithmetic(max_lon - 25))
                 &
                 ((data.lat <= -60) | (data.lat >= 60))
             )
@@ -83,9 +83,9 @@ def calculate_lat_lon_filter_condition(data, min_lat, max_lat, min_lon, max_lon,
         # 3rd tier, +/- 45 degrees at 70-80 absolute latitude
         if special_meridian_logic:
             longitude_condition |= (
-                (data.lon < normalize_longitude_arithmetic(min_lon - 45))
+                (data.lon < normalize_longitude_arithmetic(min_lon + 45))
                 |
-                (data.lon >= normalize_longitude_arithmetic(max_lon + 45))
+                (data.lon >= normalize_longitude_arithmetic(max_lon - 45))
                 &
                 ((data.lat <= -70) | (data.lat >= 70))
             )

--- a/classes/aqua_positions.py
+++ b/classes/aqua_positions.py
@@ -32,10 +32,16 @@ def calculate_lat_lon_filter_condition(data, min_lat, max_lat, min_lon, max_lon,
     lon_naively_contains_zero = (min_lon <= 0 <= max_lon)
     longitude_condition = (data.lon >= min_lon) & (data.lon < max_lon)
 
+    # special logic for meridian setting
+    if not ((lon_naively_contains_zero and include_prime_meridian) or
+            (not lon_naively_contains_zero and not include_prime_meridian)):
+        # take from the complement of the usual longitude slice
+        longitude_condition = ~longitude_condition
+
     # Expand search area longitude further near the poles
     if is_search_area:
         # 1st tier, +/- 10 degrees at absolute latitude < 60
-        longitude_condition = (
+        longitude_condition |= (
             (data.lon >= normalize_longitude_arithmetic(min_lon - 10))
             &
             (data.lon < normalize_longitude_arithmetic(max_lon + 10))
@@ -62,12 +68,6 @@ def calculate_lat_lon_filter_condition(data, min_lat, max_lat, min_lon, max_lon,
         longitude_condition |= (
             ((data.lat <= -80) | (data.lat >= 80))
         )
-
-    # special logic for meridian setting
-    if not ((lon_naively_contains_zero and include_prime_meridian) or
-            (not lon_naively_contains_zero and not include_prime_meridian)):
-        # take from the complement of the usual longitude slice
-        longitude_condition = ~longitude_condition
 
     geo_condition = latitude_condition & longitude_condition
 

--- a/classes/aqua_positions.py
+++ b/classes/aqua_positions.py
@@ -97,7 +97,7 @@ def calculate_lat_lon_filter_condition(data, min_lat, max_lat, min_lon, max_lon,
                 &
                 ((data.lat <= -70) | (data.lat >= 70))
             )
-        # 4th tier, all longitudes at absolute longitude > 80
+        # 4th tier, all longitudes at absolute latitude > 80
         longitude_condition |= (
             ((data.lat <= -80) | (data.lat >= 80))
         )

--- a/classes/hdf.py
+++ b/classes/hdf.py
@@ -84,7 +84,7 @@ class HDFFilter(object):
                  cloud_cover_threshold_is_max, all_spots_avg_threshold, all_spots_avg_threshold_is_max, noise_amp,
                  dust_flag_no_dust, dust_flag_single_fov, dust_flag_detected, examine_wavenumber_mode,
                  selected_wavenumber, scanang, inside_scanang, solzen_threshold, solzen_is_max, min_lat, max_lat,
-                 min_lon, max_lon):
+                 min_lon, max_lon, include_prime_meridian):
         self.use_radiance_filters = use_radiance_filters
         self.radiance = radiance
         self.radiance_range = radiance_range
@@ -112,6 +112,7 @@ class HDFFilter(object):
         self.max_lat = max_lat
         self.min_lon = min_lon
         self.max_lon = max_lon
+        self.include_prime_meridian = include_prime_meridian
 
 
 class HDFStorage(object):

--- a/classes/hdf.py
+++ b/classes/hdf.py
@@ -363,8 +363,8 @@ def extract_granule_dataset(granule, hdf_filter: HDFFilter):
 
 def filter_dataset(df: pd.DataFrame, radiances: pd.DataFrame, radiances_quality: pd.DataFrame, hdf_filter: HDFFilter):
     # Pre-filter data to only include data points within lat/lon specification
-    prefilter_geo_condition = (df.latitude >= hdf_filter.min_lat) & (df.latitude <= hdf_filter.max_lat)
-    prefilter_geo_condition &= (df.longitude >= hdf_filter.min_lon) & (df.longitude <= hdf_filter.max_lon)
+    prefilter_geo_condition = (df.latitude >= hdf_filter.min_lat) & (df.latitude < hdf_filter.max_lat)
+    prefilter_geo_condition &= (df.longitude >= hdf_filter.min_lon) & (df.longitude < hdf_filter.max_lon)
     radiances = radiances[prefilter_geo_condition]
 
     # start counting amount of data points removed by filters

--- a/classes/hdf.py
+++ b/classes/hdf.py
@@ -12,7 +12,7 @@ import requests
 
 from classes.constants import CHANNELS_TO_WAVELENGTHS
 from ._http import SessionWithHeaderRedirection
-from .aqua_positions import calculate_longitude_filter_condition
+from .aqua_positions import calculate_lat_lon_filter_condition
 
 
 def print_stats(filter_stats):
@@ -365,11 +365,10 @@ def extract_granule_dataset(granule, hdf_filter: HDFFilter):
 
 def filter_dataset(df: pd.DataFrame, radiances: pd.DataFrame, radiances_quality: pd.DataFrame, hdf_filter: HDFFilter):
     # Pre-filter data to only include data points within lat/lon specification
-    prefilter_geo_condition = (df.latitude >= hdf_filter.min_lat) & (df.latitude < hdf_filter.max_lat)
-
-    longitude_condition = calculate_longitude_filter_condition(df, hdf_filter.min_lon, hdf_filter.max_lon,
-                                                               hdf_filter.include_prime_meridian, is_search_area=False)
-    prefilter_geo_condition &= longitude_condition
+    prefilter_geo_condition = calculate_lat_lon_filter_condition(df, hdf_filter.min_lat, hdf_filter.max_lat,
+                                                                 hdf_filter.min_lon, hdf_filter.max_lon,
+                                                                 hdf_filter.include_prime_meridian,
+                                                                 is_search_area=False)
     radiances = radiances[prefilter_geo_condition]
 
     # start counting amount of data points removed by filters

--- a/classes/hdf.py
+++ b/classes/hdf.py
@@ -371,6 +371,8 @@ def filter_dataset(df: pd.DataFrame, radiances: pd.DataFrame, radiances_quality:
                                                                  hdf_filter.include_prime_meridian,
                                                                  is_search_area=False)
     radiances = radiances[prefilter_geo_condition]
+    df = df[prefilter_geo_condition]
+    radiances_quality = radiances_quality[prefilter_geo_condition]
 
     # start counting amount of data points removed by filters
     num_data_points = radiances.count().sum()

--- a/classes/hdf.py
+++ b/classes/hdf.py
@@ -365,6 +365,7 @@ def extract_granule_dataset(granule, hdf_filter: HDFFilter):
 
 def filter_dataset(df: pd.DataFrame, radiances: pd.DataFrame, radiances_quality: pd.DataFrame, hdf_filter: HDFFilter):
     # Pre-filter data to only include data points within lat/lon specification
+    df = df.rename(columns={'latitude': 'lat', 'longitude': 'lon'})
     prefilter_geo_condition = calculate_lat_lon_filter_condition(df, hdf_filter.min_lat, hdf_filter.max_lat,
                                                                  hdf_filter.min_lon, hdf_filter.max_lon,
                                                                  hdf_filter.include_prime_meridian,
@@ -383,24 +384,24 @@ def filter_dataset(df: pd.DataFrame, radiances: pd.DataFrame, radiances_quality:
             print("ERROR: Invalid wavenumber selected: " + str(hdf_filter.selected_wavenumber))
 
     radiances_by_latitude_mask = {
-        '-90to-80': (df.latitude >= -90) & (df.latitude < -80),
-        '-80to-70': (df.latitude >= -80) & (df.latitude < -70),
-        '-70to-60': (df.latitude >= -70) & (df.latitude < -60),
-        '-60to-50': (df.latitude >= -60) & (df.latitude < -50),
-        '-50to-40': (df.latitude >= -50) & (df.latitude < -40),
-        '-40to-30': (df.latitude >= -40) & (df.latitude < -30),
-        '-30to-20': (df.latitude >= -30) & (df.latitude < -20),
-        '-20to-10': (df.latitude >= -20) & (df.latitude < -10),
-        '-10to0': (df.latitude >= -10) & (df.latitude < 0),
-        '0to10': (df.latitude >= 0) & (df.latitude <= 10),
-        '10to20': (df.latitude > 10) & (df.latitude <= 20),
-        '20to30': (df.latitude > 20) & (df.latitude <= 30),
-        '30to40': (df.latitude > 30) & (df.latitude <= 40),
-        '40to50': (df.latitude > 40) & (df.latitude <= 50),
-        '50to60': (df.latitude > 50) & (df.latitude <= 60),
-        '60to70': (df.latitude > 60) & (df.latitude <= 70),
-        '70to80': (df.latitude > 70) & (df.latitude <= 80),
-        '80to90': (df.latitude > 80) & (df.latitude <= 90)
+        '-90to-80': (df.lat >= -90) & (df.lat < -80),
+        '-80to-70': (df.lat >= -80) & (df.lat < -70),
+        '-70to-60': (df.lat >= -70) & (df.lat < -60),
+        '-60to-50': (df.lat >= -60) & (df.lat < -50),
+        '-50to-40': (df.lat >= -50) & (df.lat < -40),
+        '-40to-30': (df.lat >= -40) & (df.lat < -30),
+        '-30to-20': (df.lat >= -30) & (df.lat < -20),
+        '-20to-10': (df.lat >= -20) & (df.lat < -10),
+        '-10to0': (df.lat >= -10) & (df.lat < 0),
+        '0to10': (df.lat >= 0) & (df.lat <= 10),
+        '10to20': (df.lat > 10) & (df.lat <= 20),
+        '20to30': (df.lat > 20) & (df.lat <= 30),
+        '30to40': (df.lat > 30) & (df.lat <= 40),
+        '40to50': (df.lat > 40) & (df.lat <= 50),
+        '50to60': (df.lat > 50) & (df.lat <= 60),
+        '60to70': (df.lat > 60) & (df.lat <= 70),
+        '70to80': (df.lat > 70) & (df.lat <= 80),
+        '80to90': (df.lat > 80) & (df.lat <= 90)
     }
 
     # max landFrac

--- a/classes/hdf.py
+++ b/classes/hdf.py
@@ -83,7 +83,8 @@ class HDFFilter(object):
                  data_quality_worst, landfrac_threshold, landfrac_threshold_is_max, cloud_cover_threshold,
                  cloud_cover_threshold_is_max, all_spots_avg_threshold, all_spots_avg_threshold_is_max, noise_amp,
                  dust_flag_no_dust, dust_flag_single_fov, dust_flag_detected, examine_wavenumber_mode,
-                 selected_wavenumber, scanang, inside_scanang, solzen_threshold, solzen_is_max):
+                 selected_wavenumber, scanang, inside_scanang, solzen_threshold, solzen_is_max, min_lat, max_lat,
+                 min_lon, max_lon):
         self.use_radiance_filters = use_radiance_filters
         self.radiance = radiance
         self.radiance_range = radiance_range
@@ -107,6 +108,10 @@ class HDFFilter(object):
         self.inside_scanang = inside_scanang
         self.solzen_threshold = solzen_threshold
         self.solzen_is_max = solzen_is_max
+        self.min_lat = min_lat
+        self.max_lat = max_lat
+        self.min_lon = min_lon
+        self.max_lon = max_lon
 
 
 class HDFStorage(object):

--- a/classes/hdf.py
+++ b/classes/hdf.py
@@ -12,6 +12,7 @@ import requests
 
 from classes.constants import CHANNELS_TO_WAVELENGTHS
 from ._http import SessionWithHeaderRedirection
+from .aqua_positions import calculate_longitude_filter_condition
 
 
 def print_stats(filter_stats):
@@ -365,7 +366,10 @@ def extract_granule_dataset(granule, hdf_filter: HDFFilter):
 def filter_dataset(df: pd.DataFrame, radiances: pd.DataFrame, radiances_quality: pd.DataFrame, hdf_filter: HDFFilter):
     # Pre-filter data to only include data points within lat/lon specification
     prefilter_geo_condition = (df.latitude >= hdf_filter.min_lat) & (df.latitude < hdf_filter.max_lat)
-    prefilter_geo_condition &= (df.longitude >= hdf_filter.min_lon) & (df.longitude < hdf_filter.max_lon)
+
+    longitude_condition = calculate_longitude_filter_condition(df, hdf_filter.min_lon, hdf_filter.max_lon,
+                                                               hdf_filter.include_prime_meridian, is_search_area=False)
+    prefilter_geo_condition &= longitude_condition
     radiances = radiances[prefilter_geo_condition]
 
     # start counting amount of data points removed by filters

--- a/classes/hdf.py
+++ b/classes/hdf.py
@@ -320,6 +320,7 @@ def extract_granule_dataset(granule, hdf_filter: HDFFilter):
     all_spots = pd.DataFrame(data.select('all_spots_avg').get())
     final_noise_amp = pd.DataFrame(data.select('CCfinal_Noise_Amp').get())
     latitude = pd.DataFrame(data.select('Latitude').get())
+    longitude = pd.DataFrame(data.select('Longitude').get())
     scanang = pd.DataFrame(data.select('scanang').get())
     solzen = pd.DataFrame(data.select('solzen').get())
 
@@ -343,6 +344,7 @@ def extract_granule_dataset(granule, hdf_filter: HDFFilter):
         'cloud_cover': cloud_cover,
         'all_spots': all_spots,
         'latitude': latitude,
+        'longitude': longitude,
         'scanang': scanang,
         'solzen': solzen
     }
@@ -360,6 +362,11 @@ def extract_granule_dataset(granule, hdf_filter: HDFFilter):
 
 
 def filter_dataset(df: pd.DataFrame, radiances: pd.DataFrame, radiances_quality: pd.DataFrame, hdf_filter: HDFFilter):
+    # Pre-filter data to only include data points within lat/lon specification
+    prefilter_geo_condition = (df.latitude >= hdf_filter.min_lat) & (df.latitude <= hdf_filter.max_lat)
+    prefilter_geo_condition &= (df.longitude >= hdf_filter.min_lon) & (df.longitude <= hdf_filter.max_lon)
+    radiances = radiances[prefilter_geo_condition]
+
     # start counting amount of data points removed by filters
     num_data_points = radiances.count().sum()
     num_filtered_total = 0

--- a/classes/interface/main_controller.py
+++ b/classes/interface/main_controller.py
@@ -225,6 +225,10 @@ class MainController(object):
         inside_scanang = data['inside_scanang']  # bool
         solzen_threshold = float(data['solzen_threshold'])
         solzen_is_max = data['solzen_is_max']  # bool
+        min_lat = data['min_latitude']
+        max_lat = data['max_latitude']
+        min_lon = data['min_longitude']
+        max_lon = data['max_longitude']
 
         noise_amp = data['noise_amp']  # bool
         radiance = None
@@ -235,5 +239,5 @@ class MainController(object):
             data_quality_worst, landfrac_threshold, landfrac_threshold_is_max, cloud_cover_threshold,
             cloud_cover_threshold_is_max, all_spots_avg_threshold, all_spots_avg_threshold_is_max, noise_amp,
             dust_flag_no_dust, dust_flag_single_fov, dust_flag_detected, examine_wavenumber_mode, selected_wavenumber,
-            scanang, inside_scanang, solzen_threshold, solzen_is_max
+            scanang, inside_scanang, solzen_threshold, solzen_is_max, min_lat, max_lat, min_lon, max_lon
         )

--- a/classes/interface/main_controller.py
+++ b/classes/interface/main_controller.py
@@ -241,7 +241,8 @@ class MainController(object):
                 data_quality_worst, landfrac_threshold, landfrac_threshold_is_max, cloud_cover_threshold,
                 cloud_cover_threshold_is_max, all_spots_avg_threshold, all_spots_avg_threshold_is_max, noise_amp,
                 dust_flag_no_dust, dust_flag_single_fov, dust_flag_detected, examine_wavenumber_mode, selected_wavenumber,
-                scanang, inside_scanang, solzen_threshold, solzen_is_max
+                scanang, inside_scanang, solzen_threshold, solzen_is_max, min_lat, max_lat, min_lon, max_lon,
+                include_prime_meridian
             )
 
         except KeyError as e:

--- a/classes/interface/main_controller.py
+++ b/classes/interface/main_controller.py
@@ -229,6 +229,7 @@ class MainController(object):
         max_lat = data['max_latitude']
         min_lon = data['min_longitude']
         max_lon = data['max_longitude']
+        include_prime_meridian = data['include_prime_meridian']
 
         noise_amp = data['noise_amp']  # bool
         radiance = None
@@ -239,5 +240,6 @@ class MainController(object):
             data_quality_worst, landfrac_threshold, landfrac_threshold_is_max, cloud_cover_threshold,
             cloud_cover_threshold_is_max, all_spots_avg_threshold, all_spots_avg_threshold_is_max, noise_amp,
             dust_flag_no_dust, dust_flag_single_fov, dust_flag_detected, examine_wavenumber_mode, selected_wavenumber,
-            scanang, inside_scanang, solzen_threshold, solzen_is_max, min_lat, max_lat, min_lon, max_lon
+            scanang, inside_scanang, solzen_threshold, solzen_is_max, min_lat, max_lat, min_lon, max_lon,
+            include_prime_meridian
         )

--- a/test.json
+++ b/test.json
@@ -38,5 +38,7 @@
 	    "selected_wavenumber": 818.933,
 
 	    "scanang_limit": 30,
-	    "inside_scanang": true
+	    "inside_scanang": true,
+	    "solzen_threshold": 108,
+	    "solzen_is_max": false
         }

--- a/test.json
+++ b/test.json
@@ -38,7 +38,5 @@
 	    "selected_wavenumber": 818.933,
 
 	    "scanang_limit": 30,
-	    "inside_scanang": true,
-	    "solzen_threshold": 108,
-	    "solzen_is_max": false
+	    "inside_scanang": true
         }


### PR DESCRIPTION
This branch adds meridian-aware geo filtering of granule data, and an expanded search area which grows in longitude near the poles.

Definitely needs some more testing:

- Is the search area properly expanded, regardless of meridian setting?
- Does search area expansion work properly near the international date line?