### PR TITLE
Fix HDF test mode

### DIFF
--- a/classes/interface/main_controller.py
+++ b/classes/interface/main_controller.py
@@ -80,7 +80,8 @@ class MainController(object):
             )
 
         # write CSV of data and format dates as MM-YYYY
-        curves_data.to_csv(base_filename + '.csv', index=False, date_format='%m-%Y')
+        if curves_data is not None:
+            curves_data.to_csv(base_filename + '.csv', index=False, date_format='%m-%Y')
 
         return  # No longer need to show plot
 

--- a/cli.py
+++ b/cli.py
@@ -208,7 +208,7 @@ def main():
 
         # Finally, concatenate all CSVs and remove the temp folder
 
-        if not data['examine_wavenumber_mode']:
+        if not data['examine_wavenumber_mode'] and not data['test_hdf_output']:
             from pandas import concat, read_csv
 
             path = os.path.join(data['output_directory'], temp_folder_name)

--- a/cli.py
+++ b/cli.py
@@ -208,7 +208,7 @@ def main():
 
         # Finally, concatenate all CSVs and remove the temp folder
 
-        if not data['examine_wavenumber_mode'] and not data['test_hdf_output']:
+        if not data['examine_wavenumber_mode'] and 'test_hdf_output' in data and not data['test_hdf_output']:
             from pandas import concat, read_csv
 
             path = os.path.join(data['output_directory'], temp_folder_name)

--- a/cli.py
+++ b/cli.py
@@ -208,9 +208,10 @@ def main():
 
         # Finally, concatenate all CSVs and remove the temp folder
 
-        if not data['examine_wavenumber_mode'] and 'test_hdf_output' in data and not data['test_hdf_output']:
+        if not data['examine_wavenumber_mode'] and ('test_hdf_output' not in data or not data['test_hdf_output']):
             from pandas import concat, read_csv
 
+            print('Concatenating CSVs...')
             path = os.path.join(data['output_directory'], temp_folder_name)
             stats_path = os.path.join(path, 'stats')
             filenames = os.listdir(path)


### PR DESCRIPTION
This fixes the error output when 'test_hdf_output' mode is selected, and also fixes errors that occur when all data is filtered in the regular mode. If the final data is empty, it does not attempt to write files.