### PR TITLE
Fix weird output: Had to convert wavenumbers from dict_values to list

### DIFF
--- a/classes/hdf.py
+++ b/classes/hdf.py
@@ -176,7 +176,7 @@ def calculate_averages_and_filter(results, hdf_filter):
         for bucket in results[0][2].keys():
             columns.append(bucket + '_sum')
             columns.append(bucket + '_count')
-    wavelengths = pd.Series(CHANNELS_TO_WAVELENGTHS.values())
+    wavelengths = pd.Series(list(CHANNELS_TO_WAVELENGTHS.values()))
 
     data = []
     wavenumber_data = None


### PR DESCRIPTION
There appear to have been changes in the way Python handles dict_values, or the way Pandas converts from dict_values to a Series. This caused the entire hard-coded wavenumbers array to be encoded as a tuple in a Pandas Series of length 1, causing strange and incorrect output files to be produced. Explicitly converting dict_values to a list fixes this issue and produces the expected output.